### PR TITLE
addresses failure when public_ip = false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,6 +71,12 @@ locals {
   mgmt_private_security_id = [
     for i in local.external_private_index : local.bigip_map["mgmt_securitygroup_ids"][i]
   ]
+  mgmt_public_subnet_id = [
+    for subnet in local.bigip_map["mgmt_subnet_ids"] :
+    subnet["subnet_id"]
+    if subnet["public_ip"] == true
+  ]    
+    
   external_public_subnet_id = [
     for subnet in local.bigip_map["external_subnet_ids"] :
     subnet["subnet_id"]
@@ -289,7 +295,7 @@ data "template_file" "init_file" {
 
 # Create a Public IP for bigip
 resource "azurerm_public_ip" "mgmt_public_ip" {
-  count               = length(local.bigip_map["mgmt_subnet_ids"])
+  count               = length(local.mgmt_public_subnet_id)
   name                = "${local.instance_prefix}-pip-mgmt-${count.index}"
   location            = data.azurerm_resource_group.bigiprg.location
   resource_group_name = data.azurerm_resource_group.bigiprg.name

--- a/main.tf
+++ b/main.tf
@@ -559,7 +559,7 @@ data "template_file" "clustermemberDO1" {
   count    = local.total_nics == 1 ? 1 : 0
   template = file("${path.module}/onboard_do_1nic.tpl")
   vars = {
-    hostname      = length(local.mgmt_public_subnet_id) > 0 ? azurerm_public_ip.mgmt_public_ip.fqdn : azurerm_network_interface.mgmt_nic.private_ip_address
+    hostname      = length(local.mgmt_public_subnet_id) > 0 ? azurerm_public_ip.mgmt_public_ip[0].fqdn : azurerm_network_interface.mgmt_nic[0].private_ip_address
     name_servers  = join(",", formatlist("\"%s\"", ["169.254.169.253"]))
     search_domain = "f5.com"
     ntp_servers   = join(",", formatlist("\"%s\"", ["169.254.169.123"]))
@@ -570,7 +570,7 @@ data "template_file" "clustermemberDO2" {
   count    = local.total_nics == 2 ? 1 : 0
   template = file("${path.module}/onboard_do_2nic.tpl")
   vars = {
-    hostname      = length(local.mgmt_public_subnet_id) > 0 ? azurerm_public_ip.mgmt_public_ip.fqdn : azurerm_network_interface.mgmt_nic.private_ip_address
+    hostname      = length(local.mgmt_public_subnet_id) > 0 ? azurerm_public_ip.mgmt_public_ip[0].fqdn : azurerm_network_interface.mgmt_nic[0].private_ip_address
     name_servers  = join(",", formatlist("\"%s\"", ["169.254.169.253"]))
     search_domain = "f5.com"
     ntp_servers   = join(",", formatlist("\"%s\"", ["169.254.169.123"]))
@@ -585,7 +585,7 @@ data "template_file" "clustermemberDO3" {
   count    = local.total_nics == 3 ? 1 : 0
   template = file("${path.module}/onboard_do_3nic.tpl")
   vars = {
-    hostname      = length(local.mgmt_public_subnet_id) > 0 ? azurerm_public_ip.mgmt_public_ip.fqdn : azurerm_network_interface.mgmt_nic.private_ip_address
+    hostname      = length(local.mgmt_public_subnet_id) > 0 ? azurerm_public_ip.mgmt_public_ip[0].fqdn : azurerm_network_interface.mgmt_nic[0].private_ip_address
     name_servers  = join(",", formatlist("\"%s\"", ["169.254.169.253"]))
     search_domain = "f5.com"
     ntp_servers   = join(",", formatlist("\"%s\"", ["169.254.169.123"]))

--- a/main.tf
+++ b/main.tf
@@ -71,11 +71,6 @@ locals {
   mgmt_private_security_id = [
     for i in local.external_private_index : local.bigip_map["mgmt_securitygroup_ids"][i]
   ]
-  mgmt_public_subnet_id = [
-    for subnet in local.bigip_map["mgmt_subnet_ids"] :
-    subnet["subnet_id"]
-    if subnet["public_ip"] == true
-  ]    
     
   external_public_subnet_id = [
     for subnet in local.bigip_map["external_subnet_ids"] :

--- a/main.tf
+++ b/main.tf
@@ -348,8 +348,8 @@ resource "azurerm_network_interface" "mgmt_nic" {
   ip_configuration {
     name                          = "${local.instance_prefix}-mgmt-ip-${count.index}"
     subnet_id                     = local.bigip_map["mgmt_subnet_ids"][count.index]["subnet_id"]
-    private_ip_address_allocation = (length(local.mgmt_public_private_ip_primary[count.index]) > 0 ? "Static" : "Dynamic")
-    private_ip_address            = (length(local.mgmt_public_private_ip_primary[count.index]) > 0 ? local.mgmt_public_private_ip_primary[count.index] : null)
+    private_ip_address_allocation = length(local.mgmt_public_private_ip_primary) > 0 && (length(local.mgmt_public_private_ip_primary[count.index]) > 0 ? "Static" : "Dynamic")
+    private_ip_address            = length(local.mgmt_public_private_ip_primary) > 0 && (length(local.mgmt_public_private_ip_primary[count.index]) > 0 ? local.mgmt_public_private_ip_primary[count.index] : null)
     public_ip_address_id          = local.bigip_map["mgmt_subnet_ids"][count.index]["public_ip"] ? azurerm_public_ip.mgmt_public_ip[count.index].id : ""
   }
   tags = merge(local.tags, {

--- a/main.tf
+++ b/main.tf
@@ -348,8 +348,8 @@ resource "azurerm_network_interface" "mgmt_nic" {
   ip_configuration {
     name                          = "${local.instance_prefix}-mgmt-ip-${count.index}"
     subnet_id                     = local.bigip_map["mgmt_subnet_ids"][count.index]["subnet_id"]
-    private_ip_address_allocation = length(local.mgmt_public_private_ip_primary) > 0 && (length(local.mgmt_public_private_ip_primary[count.index]) > 0 ? "Static" : "Dynamic")
-    private_ip_address            = length(local.mgmt_public_private_ip_primary) > 0 && (length(local.mgmt_public_private_ip_primary[count.index]) > 0 ? local.mgmt_public_private_ip_primary[count.index] : null)
+    private_ip_address_allocation = length(local.mgmt_public_private_ip_primary) > 0 ? (length(local.mgmt_public_private_ip_primary[count.index]) > 0 ? "Static" : "Dynamic") : "Dynamic"
+    private_ip_address            = length(local.mgmt_public_private_ip_primary) > 0 ? (length(local.mgmt_public_private_ip_primary[count.index]) > 0 ? local.mgmt_public_private_ip_primary[count.index] : null) : null
     public_ip_address_id          = local.bigip_map["mgmt_subnet_ids"][count.index]["public_ip"] ? azurerm_public_ip.mgmt_public_ip[count.index].id : ""
   }
   tags = merge(local.tags, {

--- a/main.tf
+++ b/main.tf
@@ -548,17 +548,18 @@ SETTINGS
 }
 
 # Getting Public IP Assigned to BIGIP
-data "azurerm_public_ip" "f5vm01mgmtpip" {
-  name                = azurerm_public_ip.mgmt_public_ip[0].name
-  resource_group_name = data.azurerm_resource_group.bigiprg.name
-  depends_on          = [azurerm_virtual_machine.f5vm01, azurerm_virtual_machine_extension.vmext, azurerm_public_ip.mgmt_public_ip[0]]
-}
+# data "azurerm_public_ip" "f5vm01mgmtpip" {
+#   name                = azurerm_public_ip.mgmt_public_ip[0].name
+#   resource_group_name = data.azurerm_resource_group.bigiprg.name
+#   depends_on          = [azurerm_virtual_machine.f5vm01, azurerm_virtual_machine_extension.vmext, azurerm_public_ip.mgmt_public_ip[0]]
+# }
+
 
 data "template_file" "clustermemberDO1" {
   count    = local.total_nics == 1 ? 1 : 0
   template = file("${path.module}/onboard_do_1nic.tpl")
   vars = {
-    hostname      = data.azurerm_public_ip.f5vm01mgmtpip.fqdn
+    hostname      = length(local.mgmt_public_subnet_id) > 0 ? azurerm_public_ip.mgmt_public_ip.fqdn : azurerm_network_interface.mgmt_nic.private_ip_address
     name_servers  = join(",", formatlist("\"%s\"", ["169.254.169.253"]))
     search_domain = "f5.com"
     ntp_servers   = join(",", formatlist("\"%s\"", ["169.254.169.123"]))
@@ -569,7 +570,7 @@ data "template_file" "clustermemberDO2" {
   count    = local.total_nics == 2 ? 1 : 0
   template = file("${path.module}/onboard_do_2nic.tpl")
   vars = {
-    hostname      = data.azurerm_public_ip.f5vm01mgmtpip.fqdn
+    hostname      = length(local.mgmt_public_subnet_id) > 0 ? azurerm_public_ip.mgmt_public_ip.fqdn : azurerm_network_interface.mgmt_nic.private_ip_address
     name_servers  = join(",", formatlist("\"%s\"", ["169.254.169.253"]))
     search_domain = "f5.com"
     ntp_servers   = join(",", formatlist("\"%s\"", ["169.254.169.123"]))
@@ -584,7 +585,7 @@ data "template_file" "clustermemberDO3" {
   count    = local.total_nics == 3 ? 1 : 0
   template = file("${path.module}/onboard_do_3nic.tpl")
   vars = {
-    hostname      = data.azurerm_public_ip.f5vm01mgmtpip.fqdn
+    hostname      = length(local.mgmt_public_subnet_id) > 0 ? azurerm_public_ip.mgmt_public_ip.fqdn : azurerm_network_interface.mgmt_nic.private_ip_address
     name_servers  = join(",", formatlist("\"%s\"", ["169.254.169.253"]))
     search_domain = "f5.com"
     ntp_servers   = join(",", formatlist("\"%s\"", ["169.254.169.123"]))

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,11 +1,13 @@
 output "mgmtPublicIP" {
   description = "The actual ip address allocated for the resource."
-  value       = data.azurerm_public_ip.f5vm01mgmtpip.ip_address
+  value       = length(local.mgmt_public_subnet_id) > 0 ? azurerm_public_ip.mgmt_public_ip[0].fqdn : azurerm_network_interface.mgmt_nic[0].private_ip_address
+
 }
 
 output "mgmtPublicDNS" {
   description = "fqdn to connect to the first vm provisioned."
-  value       = data.azurerm_public_ip.f5vm01mgmtpip.fqdn
+  value       = length(local.mgmt_public_subnet_id) > 0 ? azurerm_public_ip.mgmt_public_ip[0].fqdn : azurerm_network_interface.mgmt_nic[0].private_ip_address
+
 }
 
 


### PR DESCRIPTION
Fixes #1 

changes how public IP addresses for management nic are enumerated

fixes a related issue, discovered during testing, with a static lookup for the first management public IP address. The fqdn of the first BIG-IP was applied to all BIG-IPs built, if more than one BIG-IP is requested. Note the hardcoded zero in the snippet below.
```hcl
data "azurerm_public_ip" "f5vm01mgmtpip" {
  name                = azurerm_public_ip.mgmt_public_ip[0].name
  resource_group_name = data.azurerm_resource_group.bigiprg.name
  depends_on          = [azurerm_virtual_machine.f5vm01, azurerm_virtual_machine_extension.vmext, azurerm_public_ip.mgmt_public_ip[0]]
}
```