### PR TITLE
Added tags support to VM extensions resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -510,7 +510,13 @@ resource "azurerm_virtual_machine_extension" "vmext" {
   publisher            = "Microsoft.Azure.Extensions"
   type                 = "CustomScript"
   type_handler_version = "2.0"
-  settings             = <<SETTINGS
+
+  tags = merge(local.tags, {
+    Name = format("%s-vmext1", local.instance_prefix)
+    }
+  )
+
+  settings = <<SETTINGS
     {
       "commandToExecute": "bash /var/lib/waagent/CustomData; exit 0;"
     }


### PR DESCRIPTION
Currently VM Extension resource does not apply the tags provided in the module variables, the way other resources do.
This causes issues when running in environments with tag policies in place, causing false-positive "changed" behavior.

This PR fixes this by adding tags block the same way as it applied to the rest of the resources in the module that support tags.