### PR TITLE
Code suggestion: limit recreation scenarios of bigip vm

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -436,6 +436,12 @@ resource "azurerm_network_interface_application_security_group_association" "int
 
 # Create F5 BIGIP1
 resource "azurerm_linux_virtual_machine" "f5vm01" {
+  lifecycle {
+    ignore_changes = [
+      admin_password,
+      custom_data
+    ]
+  }
   name                            = var.vm_name == "" ? format("%s-f5vm01", local.instance_prefix) : var.vm_name
   location                        = var.location
   resource_group_name             = var.resource_group_name

--- a/main.tf
+++ b/main.tf
@@ -199,8 +199,8 @@ data "azurerm_client_config" "current" {
 resource "azurerm_user_assigned_identity" "user_identity" {
   count               = var.user_identity == null ? 1 : 0
   name                = format("%s-ident", local.instance_prefix)
-  resource_group_name = data.azurerm_resource_group.bigiprg.name
-  location            = data.azurerm_resource_group.bigiprg.location
+  resource_group_name = var.resource_group_name
+  location            = var.location
   tags = merge(local.tags, {
     Name = format("%s-ident", local.instance_prefix)
     }
@@ -255,8 +255,8 @@ resource "random_string" "password" {
 resource "azurerm_public_ip" "mgmt_public_ip" {
   count               = length(local.mgmt_public_subnet_id)
   name                = "${local.instance_prefix}-pip-mgmt-${count.index}"
-  location            = data.azurerm_resource_group.bigiprg.location
-  resource_group_name = data.azurerm_resource_group.bigiprg.name
+  location            = var.location
+  resource_group_name = var.resource_group_name
   domain_name_label   = format("%s-mgmt-%s", local.instance_prefix, count.index)
   allocation_method   = "Static"   # Static is required due to the use of the Standard sku
   sku                 = "Standard" # the Standard sku is required due to the use of availability zones
@@ -270,8 +270,8 @@ resource "azurerm_public_ip" "mgmt_public_ip" {
 resource "azurerm_public_ip" "external_public_ip" {
   count               = length(local.external_public_subnet_id)
   name                = "${local.instance_prefix}-pip-ext-${count.index}"
-  location            = data.azurerm_resource_group.bigiprg.location
-  resource_group_name = data.azurerm_resource_group.bigiprg.name
+  location            = var.location
+  resource_group_name = var.resource_group_name
   domain_name_label   = format("%s-ext-%s", local.instance_prefix, count.index)
   allocation_method   = "Static"   # Static is required due to the use of the Standard sku
   sku                 = "Standard" # the Standard sku is required due to the use of availability zones
@@ -284,8 +284,8 @@ resource "azurerm_public_ip" "external_public_ip" {
 resource "azurerm_public_ip" "secondary_external_public_ip" {
   count               = var.cfe_secondary_vip_disable ? 0 : length(local.external_public_subnet_id)
   name                = "${local.instance_prefix}-secondary-pip-ext-${count.index}"
-  location            = data.azurerm_resource_group.bigiprg.location
-  resource_group_name = data.azurerm_resource_group.bigiprg.name
+  location            = var.location
+  resource_group_name = var.resource_group_name
   domain_name_label   = format("%s-sec-ext-%s", local.instance_prefix, count.index)
   allocation_method   = "Static"   # Static is required due to the use of the Standard sku
   sku                 = "Standard" # the Standard sku is required due to the use of availability zones
@@ -299,8 +299,8 @@ resource "azurerm_public_ip" "secondary_external_public_ip" {
 resource "azurerm_network_interface" "mgmt_nic" {
   count               = length(local.bigip_map["mgmt_subnet_ids"])
   name                = "${local.instance_prefix}-mgmt-nic-${count.index}"
-  location            = data.azurerm_resource_group.bigiprg.location
-  resource_group_name = data.azurerm_resource_group.bigiprg.name
+  location            = var.location
+  resource_group_name = var.resource_group_name
   ip_configuration {
     name                          = "${local.instance_prefix}-mgmt-ip-${count.index}"
     subnet_id                     = local.bigip_map["mgmt_subnet_ids"][count.index]["subnet_id"]
@@ -317,8 +317,8 @@ resource "azurerm_network_interface" "mgmt_nic" {
 resource "azurerm_network_interface" "external_nic" {
   count                = length(local.external_private_subnet_id)
   name                 = "${local.instance_prefix}-ext-nic-${count.index}"
-  location             = data.azurerm_resource_group.bigiprg.location
-  resource_group_name  = data.azurerm_resource_group.bigiprg.name
+  location             = var.location
+  resource_group_name  = var.resource_group_name
   enable_ip_forwarding = var.external_enable_ip_forwarding
   ip_configuration {
     name                          = "${local.instance_prefix}-ext-ip-${count.index}"
@@ -343,8 +343,8 @@ resource "azurerm_network_interface" "external_nic" {
 resource "azurerm_network_interface" "external_public_nic" {
   count                = length(local.external_public_subnet_id)
   name                 = "${local.instance_prefix}-ext-nic-public-${count.index}"
-  location             = data.azurerm_resource_group.bigiprg.location
-  resource_group_name  = data.azurerm_resource_group.bigiprg.name
+  location             = var.location
+  resource_group_name  = var.resource_group_name
   enable_ip_forwarding = var.external_enable_ip_forwarding
 
   ip_configuration {
@@ -374,8 +374,8 @@ resource "azurerm_network_interface" "external_public_nic" {
 resource "azurerm_network_interface" "internal_nic" {
   count               = length(local.internal_private_subnet_id)
   name                = "${local.instance_prefix}-int-nic${count.index}"
-  location            = data.azurerm_resource_group.bigiprg.location
-  resource_group_name = data.azurerm_resource_group.bigiprg.name
+  location            = var.location
+  resource_group_name = var.resource_group_name
   //enable_accelerated_networking = var.enable_accelerated_networking
 
   ip_configuration {
@@ -437,8 +437,8 @@ resource "azurerm_network_interface_application_security_group_association" "int
 # Create F5 BIGIP1
 resource "azurerm_linux_virtual_machine" "f5vm01" {
   name                            = var.vm_name == "" ? format("%s-f5vm01", local.instance_prefix) : var.vm_name
-  location                        = data.azurerm_resource_group.bigiprg.location
-  resource_group_name             = data.azurerm_resource_group.bigiprg.name
+  location                        = var.location
+  resource_group_name             = var.resource_group_name
   network_interface_ids           = concat(azurerm_network_interface.mgmt_nic.*.id, azurerm_network_interface.external_nic.*.id, azurerm_network_interface.external_public_nic.*.id, azurerm_network_interface.internal_nic.*.id)
   size                            = var.f5_instance_type
   disable_password_authentication = var.enable_ssh_key
@@ -531,6 +531,6 @@ resource "time_sleep" "wait_for_azurerm_virtual_machine_f5vm" {
 # Getting Public IP Assigned to BIGIP
 # data "azurerm_public_ip" "f5vm01mgmtpip" {
 #   name                = azurerm_public_ip.mgmt_public_ip[0].name
-#   resource_group_name = data.azurerm_resource_group.bigiprg.name
+#   resource_group_name = var.resource_group_name
 #   depends_on          = [azurerm_virtual_machine.f5vm01, azurerm_virtual_machine_extension.vmext, azurerm_public_ip.mgmt_public_ip[0]]
 # }

--- a/main.tf
+++ b/main.tf
@@ -187,10 +187,6 @@ resource "random_id" "module_id" {
   byte_length = 2
 }
 
-data "azurerm_resource_group" "bigiprg" {
-  name = var.resource_group_name
-}
-
 data "azurerm_subscription" "current" {
 }
 data "azurerm_client_config" "current" {

--- a/variables.tf
+++ b/variables.tf
@@ -324,3 +324,8 @@ variable "sleep_time" {
   default     = "300s"
   description = "The number of seconds/minutes of delay to build into creation of BIG-IP VMs; default is 250. BIG-IP requires a few minutes to complete the onboarding process and this value can be used to delay the processing of dependent Terraform resources."
 }
+
+variable "location" {
+  description = "The Azure region to deploy to"
+  type        = string
+}


### PR DESCRIPTION
I am suggesting these changes to the module to stop redeployment of the VM because of 'known after apply' behavior in terraform.

We observed frequent destructive changes to the infra when rerunning identical code. We suspect this being due to certain values not being predictable by terraform forcing recreation of the VM.

Values that were marked as 'known after apply' include `resource_group_name` and `location`, both of which were derived from the data source `azurerm_resource_group.bigiprg`. This data source seemed to serve no purpose other than provide access to these mostly static values.

Furthermore `admin_password` and `custom_data` also have similar behavior because they are 'sensitive values'. To prevent these properties from causing a redeployment of the VM I added these as `lifecycle` properties with `ignore_changes` 

I do see some merit to having `custom_data` changes trigger a redeploy as the data in this block is not as static however it might be better to force a user to consciously remove the resource via `terraform destroy` or deletion of the VM; an update in place is not supported either way and there are more downsides to the unneeded redeployment that these fixes remediate than there are upsides to having modification to `custom_data` trigger an automated redeploy of the entire VM. 

![image](https://github.com/F5Networks/terraform-azure-bigip-module/assets/58708777/3ecce9dd-f578-43ed-a171-42cbf0f6aa3e)
